### PR TITLE
Handle quotes within triple quotes and (*)

### DIFF
--- a/syntax/fsharp.vim
+++ b/syntax/fsharp.vim
@@ -134,6 +134,7 @@ syn match    fsharpCharacter    "'\\\d\d\d'\|'\\[\'ntbr]'\|'.'"
 syn match    fsharpCharErr      "'\\\d\d'\|'\\\d'"
 syn match    fsharpCharErr      "'\\[^\'ntbr]'"
 syn region   fsharpString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=fsharpFormat
+syn region   fsharpString       start=+"""+ skip=+\\\\\|\\"+ end=+"""+ contains=fsharpFormat
 
 syn match    fsharpFunDef       "->"
 syn match    fsharpRefAssign    ":="
@@ -161,6 +162,7 @@ syn match    fsharpKeyChar      "\*"
 syn match    fsharpKeyChar      "+"
 syn match    fsharpKeyChar      "="
 syn match    fsharpKeyChar      "|"
+syn match    fsharpKeyChar      "(\*)"
 
 syn match    fsharpOperator     "<-"
 


### PR DESCRIPTION
I'm a bit new to vim but these changes seem to handle #5.

Also handles when you do (*) (i.e. try to use the multiplication operator as a function) and you get a similiar issue where the rest of the code is commented out.