### PR TITLE
Handle verbatim string format

### DIFF
--- a/syntax/fsharp.vim
+++ b/syntax/fsharp.vim
@@ -135,6 +135,7 @@ syn match    fsharpCharErr      "'\\\d\d'\|'\\\d'"
 syn match    fsharpCharErr      "'\\[^\'ntbr]'"
 syn region   fsharpString       start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=fsharpFormat
 syn region   fsharpString       start=+"""+ skip=+\\\\\|\\"+ end=+"""+ contains=fsharpFormat
+syn region   fsharpString       start=+@"+ skip=+""+ end=+"+ contains=fsharpFormat
 
 syn match    fsharpFunDef       "->"
 syn match    fsharpRefAssign    ":="


### PR DESCRIPTION
Verbatim strings (`@"C:\File\Path\Here\"`) aren't being syntax highlighted correctly; this isn't really noticeable until a verbatim string ends with an escaped quote. Used #14 as a reference, as I'm not super familiar with vimscript or syntax files either. :grin: 

Before:

![screen shot 2015-06-09 at 12 59 46 pm](https://cloud.githubusercontent.com/assets/1761309/8064231/738222a0-0ea7-11e5-930a-5c33f940639d.png)

After:

![screen shot 2015-06-09 at 12 59 33 pm](https://cloud.githubusercontent.com/assets/1761309/8064230/737eb322-0ea7-11e5-9178-66de3612c96d.png)
