### PR TITLE
Discover MSBuild.exe path at compile time

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -62,7 +62,9 @@ build_commands = ['curl', 'make', 'mozroots', 'touch', 'unzip']
 
 2. Run _install.cmd_
 
-3. Currently you will most likely need to set g:fsharp_xbuild_path and g:fsharp_interactive_bin to appropriate values. 
+3. The path to _msbuild.exe_ is identified automatically. It can be set manually by running ``install.cmd build="/path/to/msbuild.exe"`` or by setting ``g:fsharp_xbuild_path`` to the appropriate value.
+
+4. Currently you will most likely need to set ``g:fsharp_interactive_bin`` to the path to ``fsi.exe``.
 
 ####Syntastic
 

--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -1,6 +1,6 @@
 " Vim autoload functions
 " Language:     F#
-" Last Change:  Mon 20 Oct 2014 08:21:43 PM CEST
+" Last Change:  Wen 07 Oct 2015
 " Maintainer:   Gregor Uhlenheuer <kongo2002@googlemail.com>
 
 if exists('g:loaded_autoload_fsharpbinding_python')
@@ -67,9 +67,9 @@ function! fsharpbinding#python#BuildProject(...)
     try
         execute 'wa'
         if a:0 > 0
-            execute '!xbuild ' . fnameescape(a:1)
+            execute '!' . g:fsharp_xbuild_path . ' ' . fnameescape(a:1)
         elseif exists('b:proj_file')
-            execute '!xbuild ' . fnameescape(b:proj_file) "/verbosity:quiet /nologo"
+            execute '!' . g:fsharp_xbuild_path . ' ' . fnameescape(b:proj_file) "/verbosity:quiet /nologo"
             call fsharpbinding#python#ParseProject()
             let b:fsharp_buffer_changed = 1
         else

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -13,7 +13,7 @@ if !exists('g:fsharp_only_check_errors_on_write')
     let g:fsharp_only_check_errors_on_write = 0
 endif
 if !exists('g:fsharp_xbuild_path')
-    let g:fsharp_xbuild_path = {BUILD_EXECUTABLE}
+    let g:fsharp_xbuild_path = 'xbuild'
 endif
 if !exists('g:fsharp_completion_helptext')
     let g:fsharp_completion_helptext = 1

--- a/ftplugin/fsharp.vim.template
+++ b/ftplugin/fsharp.vim.template
@@ -1,6 +1,6 @@
 " Vim filetype plugin
 " Language:     F#
-" Last Change:  Thu 23 Oct 2014 08:39:53 PM CEST
+" Last Change:  Wen 07 Oct 2015
 " Maintainer:   Gregor Uhlenheuer <kongo2002@googlemail.com>
 
 if exists('b:did_ftplugin')
@@ -13,7 +13,7 @@ if !exists('g:fsharp_only_check_errors_on_write')
     let g:fsharp_only_check_errors_on_write = 0
 endif
 if !exists('g:fsharp_xbuild_path')
-    let g:fsharp_xbuild_path = "xbuild"
+    let g:fsharp_xbuild_path = {BUILD_EXECUTABLE}
 endif
 if !exists('g:fsharp_completion_helptext')
     let g:fsharp_completion_helptext = 1 

--- a/install.fsx
+++ b/install.fsx
@@ -20,8 +20,42 @@ let syntaxDir = __SOURCE_DIRECTORY__ @@ "syntax"
 let ftdetectDir = __SOURCE_DIRECTORY__ @@ "ftdetect"
 let syntaxCheckersDir = __SOURCE_DIRECTORY__ @@ "syntax_checkers"
 
+let fsharpVim = ftpluginDir @@ "fsharp.vim"
+
 let acArchive = "fsautocomplete.zip"
 let acVersion = "0.23.0"
+
+let buildExecutable = 
+  // The build executable can be set as an environment variable.
+  // For example: ./install.cmd -ev build "path/to/msbuild"
+  if isMono then getBuildParamOrDefault "build" "xbuild"
+  else
+    // In Windows, 'shellescape' is needed to escape the path for vim
+    sprintf "shellescape('%s')" <| getBuildParamOrDefault "build"
+      (let key = "SOFTWARE\\Microsoft\\MSBuild\\ToolsVersions" 
+ 
+       let toolsVersions = 
+         match RegistryHelper.getRegistryKey HKEYLocalMachine key false with
+         | null -> failwith "MSBuild could not be found in the System Registry (no ToolsVersion installed)."
+         | key -> key
+ 
+       let mostRecentVersionKey =
+         match toolsVersions.GetSubKeyNames () with
+         | [||] -> failwith "MSBuild could not be found in the System Registry (no ToolsVersion installed)."
+         | versions -> versions 
+                       |> Array.maxBy System.Version
+                       |> sprintf "%s\\%s" key
+ 
+       if valueExistsForKey HKEYLocalMachine mostRecentVersionKey "MSBuildToolsPath"
+       then 
+         let path =  
+           RegistryHelper.getRegistryValue HKEYLocalMachine mostRecentVersionKey "MSBuildToolsPath" 
+         let executable = normalizePath (path @@ "MSBuild.exe")
+         if fileExists executable then executable
+         else failwithf "File not found: %s" executable
+       else 
+         sprintf "HKEY_LOCAL_MACHINE\\%s" mostRecentVersionKey
+         |> failwithf "Registry key 'MSBuildToolsPath' missing in: %s.")
 
 Target "FSharp.AutoComplete" (fun _ ->
   CreateDir vimBinDir
@@ -32,10 +66,14 @@ Target "FSharp.AutoComplete" (fun _ ->
   tracefn "Unzipping"
   Unzip vimBinDir (vimBinDir @@ acArchive))
 
+Target "AddPath" (fun _ ->
+    CopyFile fsharpVim (fsharpVim + ".template")
+    processTemplates ["{BUILD_EXECUTABLE}", buildExecutable] [fsharpVim])
+
 Target "Install" (fun _ ->
     DeleteDir vimInstallDir
     CreateDir vimInstallDir
-    CopyDir (vimInstallDir @@ "ftplugin") ftpluginDir (fun _ -> true)
+    CopyDir (vimInstallDir @@ "ftplugin") ftpluginDir (function EndsWith ".template" -> false | _ -> true)
     CopyDir (vimInstallDir @@ "autoload") autoloadDir (fun _ -> true)
     CopyDir (vimInstallDir @@ "syntax") syntaxDir (fun _ -> true)
     CopyDir (vimInstallDir @@ "syntax_checkers") syntaxCheckersDir (fun _ -> true)
@@ -47,6 +85,7 @@ Target "Clean" (fun _ ->
 Target "All" id
 
 "FSharp.AutoComplete"
+    ==> "AddPath"
     ==> "Install"
     ==> "All"
 

--- a/paket.lock
+++ b/paket.lock
@@ -1,4 +1,4 @@
 NUGET
   remote: https://nuget.org/api/v2
   specs:
-    FAKE (3.33.0)
+    FAKE (4.4.6)


### PR DESCRIPTION
- Create a template file for ftplugin/fsharp.vim (where the path will be inserted)
- Allow the path to be set at compile time with an environment variable:
  ./install.cmd -ev build "/path/to/build/executable"
- Correct ``:FSharpBuildProject`` to use the variable ``g:fsharp_xbuild_path``
- Update FAKE version to 4.4.6
- This fixes #23