### PR TITLE
Discover path to FSI and MSBuild/xbuild using fsautocomplete

### DIFF
--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -1,6 +1,6 @@
 " Vim autoload functions
 " Language:     F#
-" Last Change:  Mon 20 Oct 2014 08:21:43 PM CEST
+" Last Change:  Fri 16 Oct 2015
 " Maintainer:   Gregor Uhlenheuer <kongo2002@googlemail.com>
 
 if exists('g:loaded_autoload_fsharpbinding_python')
@@ -67,9 +67,9 @@ function! fsharpbinding#python#BuildProject(...)
     try
         execute 'wa'
         if a:0 > 0
-            execute '!xbuild ' . fnameescape(a:1)
+            execute '!' . shellescape(g:fsharp_xbuild_path) . ' ' . fnameescape(a:1)
         elseif exists('b:proj_file')
-            execute '!xbuild ' . fnameescape(b:proj_file) "/verbosity:quiet /nologo"
+            execute '!' . shellescape(g:fsharp_xbuild_path) . ' ' . fnameescape(b:proj_file) "/verbosity:quiet /nologo"
             call fsharpbinding#python#ParseProject()
             let b:fsharp_buffer_changed = 1
         else
@@ -211,7 +211,7 @@ for line in G.fsac.complete(b.name, row, col + 1, vim.eval('a:base')):
     if int(vim.eval('g:fsharp_completion_helptext')) > 0:
         ht = G.fsac.helptext(name)
         x = {'word': name,
-             'info': ht, 
+             'info': ht,
              'menu': glyph}
         vim.eval('complete_add(%s)' % x)
     else:
@@ -272,7 +272,7 @@ EOF
 endfunction
 
 function! fsharpbinding#python#OnInsertLeave()
-    if exists ("b:fsharp_buffer_changed") != 0 
+    if exists ("b:fsharp_buffer_changed") != 0
         if b:fsharp_buffer_changed == 1
     python << EOF
 G.fsac.parse(vim.current.buffer.name, True, vim.current.buffer)
@@ -282,7 +282,7 @@ EOF
 endfunction
 
 function! fsharpbinding#python#OnCursorHold()
-    if exists ("g:fsharp_only_check_errors_on_write") != 0 
+    if exists ("g:fsharp_only_check_errors_on_write") != 0
         if g:fsharp_only_check_errors_on_write != 1 && b:fsharp_buffer_changed == 1
             exec "SyntasticCheck"
         endif
@@ -316,7 +316,7 @@ EOF
     "set makeprg
     if !filereadable(expand("%:p:h")."/Makefile")
         if exists('b:proj_file')
-            let &l:makeprg=g:fsharp_xbuild_path . ' ' . b:proj_file . ' /verbosity:quiet /nologo /p:Configuration=Debug'
+            let &l:makeprg=shellescape(g:fsharp_xbuild_path) . ' ' . b:proj_file . ' /verbosity:quiet /nologo /p:Configuration=Debug'
             setlocal errorformat=\ %#%f(%l\\\,%c):\ %m
         endif
     endif
@@ -358,7 +358,7 @@ function! fsharpbinding#python#FsiShow()
             exec 'wincmd p'
         endif
     catch
-        echohl WarningMsg "failed to display fsi output" 
+        echohl WarningMsg "failed to display fsi output"
     endtry
 endfunction
 
@@ -413,7 +413,7 @@ function! fsharpbinding#python#FsiEval(text)
         endif
         call fsharpbinding#python#FsiRead(5)
     catch
-        echohl WarningMsg "fsi eval failure" 
+        echohl WarningMsg "fsi eval failure"
     endtry
 endfunction
 

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin
 " Language:     F#
-" Last Change:  Thu 23 Oct 2014 08:39:53 PM CEST
+" Last Change:  Fri 16 Oct 2015
 " Maintainer:   Gregor Uhlenheuer <kongo2002@googlemail.com>
 
 if exists('b:did_ftplugin')
@@ -12,48 +12,42 @@ let b:did_ftplugin = 1
 if !exists('g:fsharp_only_check_errors_on_write')
     let g:fsharp_only_check_errors_on_write = 0
 endif
-if !exists('g:fsharp_xbuild_path')
-    let g:fsharp_xbuild_path = "xbuild"
-endif
 if !exists('g:fsharp_completion_helptext')
-    let g:fsharp_completion_helptext = 1 
+    let g:fsharp_completion_helptext = 1
 endif
 
 let s:cpo_save = &cpo
 set cpo&vim
-
-let s:candidates = [ 'fsi',
-            \ 'fsi.exe',
-            \ 'fsharpi',
-            \ 'fsharpi.exe' ]
-
-if !exists('g:fsharp_interactive_bin')
-    let g:fsharp_interactive_bin = ''
-    for c in s:candidates
-        if executable(c)
-            let g:fsharp_interactive_bin = c
-            break
-        endif
-    endfor
-endif
 
 " check for python support
 if has('python')
     python <<EOF
 import vim
 import os
+import re
 fsharp_dir = vim.eval("expand('<sfile>:p:h')")
 file_dir = vim.eval("expand('%:p:h')")
 sys.path.append(fsharp_dir)
 
-from fsharpvim import FSAutoComplete,G
-from fsi import FSharpInteractive 
+from fsharpvim import FSAutoComplete, G
+from fsi import FSharpInteractive
 import pyvim
 
 debug = vim.eval("get(g:, 'fsharpbinding_debug', 0)") != '0'
-if G.fsac == None:
-    G.fsac = FSAutoComplete(fsharp_dir, debug)
-if G.fsi == None:
+if G.fsac is None:
+   G.fsac = FSAutoComplete(fsharp_dir, debug)
+vim_var_exists = lambda var_name: vim.eval("exists('%s')" % var_name) != '0'
+# retrieve path to a compiler tool (fsi, msbuild/xbuild) with fsautocomplete unless set by the user
+def get_path(var_name, path_obj):
+    if vim_var_exists(var_name):
+        return
+    if path_obj not in G.paths:
+        G.paths = G.fsac.get_paths()
+    if path_obj in G.paths:
+        vim.command('let %s = "%s"' % (var_name, re.escape(G.paths[path_obj])))
+get_path('g:fsharp_interactive_bin', 'Fsi')
+get_path('g:fsharp_xbuild_path', 'MSBuild')
+if G.fsi is None and vim_var_exists('g:fsharp_interactive_bin'):
     G.fsi = FSharpInteractive(vim.eval('g:fsharp_interactive_bin'), debug)
 
 #find project file if any - assumes fsproj file will be in the same directory as the fs or fsi file
@@ -80,7 +74,7 @@ EOF
     com! -buffer -nargs=* -complete=file FSharpBuildProject call fsharpbinding#python#BuildProject(<f-args>)
     com! -buffer -nargs=* -complete=file FSharpRunTests call fsharpbinding#python#RunTests(<f-args>)
     com! -buffer -nargs=* -complete=file FSharpRunProject call fsharpbinding#python#RunProject(<f-args>)
-    
+
     "fsi
     com! -buffer FsiShow call fsharpbinding#python#FsiShow()
     com! -buffer FsiClear call fsharpbinding#python#FsiClear()
@@ -98,7 +92,7 @@ EOF
         au!
         " closing the scratch window after leaving insert mode
         " is common practice
-        au BufWritePre  *.fs,*.fsi,*fsx call fsharpbinding#python#OnBufWritePre() 
+        au BufWritePre  *.fs,*.fsi,*fsx call fsharpbinding#python#OnBufWritePre()
         if version > 703
             " these events new in Vim 7.4
             au TextChanged  *.fs,*.fsi,*fsx call fsharpbinding#python#OnTextChanged()

--- a/ftplugin/fsharpvim.py
+++ b/ftplugin/fsharpvim.py
@@ -10,8 +10,9 @@ import hidewin
 class G:
     fsac = None
     fsi = None
+    paths = {}
     locations = []
-    projects = {} 
+    projects = {}
 
 class Interaction:
     def __init__(self, proc, timeOut, logfile = None):
@@ -76,6 +77,7 @@ class FSAutoComplete:
         self._helptext = Interaction(self.p, 1, self.logfile)
         self._errors = Interaction(self.p, 3, self.logfile)
         self._project = Interaction(self.p, 3, self.logfile)
+        self._getpaths = Interaction(self.p, 1, self.logfile)
 
         self.worker = threading.Thread(target=self.work, args=(self,))
         self.worker.daemon = True
@@ -117,6 +119,8 @@ class FSAutoComplete:
                 self._project.update(data)
             elif parsed['Kind'] == "finddecl":
                 self._finddecl.update(parsed['Data'])
+            elif parsed['Kind'] == "compilerlocation":
+                self._getpaths.update(parsed['Data'])
 
     def help(self):
         self.send("help\n")
@@ -140,6 +144,9 @@ class FSAutoComplete:
 
         if self.debug:
             self.logfile.close()
+
+    def get_paths(self):
+        return self._getpaths.send("compilerlocation\n")
 
     def complete(self, fn, line, column, base):
         self.__log('complete: base = %s\n' % base)
@@ -199,7 +206,7 @@ class FSAutoComplete:
 
         if "\'" in msg and "\"" in msg:
             msg = msg.replace("\"", "") #HACK: dictionary parsing in vim gets weird if both ' and " get printed in the same string
-        elif "\n" in msg: 
+        elif "\n" in msg:
             msg = msg + "\n\n'" #HACK: - the ' is inserted to ensure that newlines are interpreted properly in the preview window
         return msg
 


### PR DESCRIPTION
This would resolve #23.

The method used in this pull request calls fsautocomplete with the command "compilerlocation" to get the paths. It only issues a call once at startup. I guess this would be the most reasonable solution.

What do you think, @kjnilsson?