### PR TITLE
Check that vim has :SyntasticCheck before calling

### DIFF
--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -282,7 +282,8 @@ EOF
 endfunction
 
 function! fsharpbinding#python#OnCursorHold()
-    if exists ("g:fsharp_only_check_errors_on_write") != 0
+    if exists ("g:fsharp_only_check_errors_on_write") != 0 &&
+    \  exists (':SyntasticCheck') == 2
         if g:fsharp_only_check_errors_on_write != 1 && b:fsharp_buffer_changed == 1
             exec "SyntasticCheck"
         endif


### PR DESCRIPTION
Users without Syntastic installed get spammed all the time by error messages in `OnCursorHold`. This change introduces a check that the command exists.