### PR TITLE
Avoid race condition in get_path on some systems

### DIFF
--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -36,6 +36,7 @@ import pyvim
 debug = vim.eval("get(g:, 'fsharpbinding_debug', 0)") != '0'
 if G.fsac is None:
    G.fsac = FSAutoComplete(fsharp_dir, debug)
+   G.fsac.get_paths()
 vim_var_exists = lambda var_name: vim.eval("exists('%s')" % var_name) != '0'
 # retrieve path to a compiler tool (fsi, msbuild/xbuild) with fsautocomplete unless set by the user
 def get_path(var_name, path_obj):


### PR DESCRIPTION
On some systems, the plugin fails to initialize due to a 'TypeError'.
TypeError: argument of type 'NoneType' is not iterable.
The embedded python code initializes G.paths to an empty map;
however, if a key is not found in the map, the code re-initializes
G.paths using G.fsac.get_paths().  On some systems, the first call
to get_paths() returns 'None'.  Checking 'None' for the key raises
the error. Adding a call to G.fsac.get_paths() when fsac is
initialized avoids the race condition.  This change does not fix the underlying
race condition, but has been tested on both a system that exhibits
the behavior and one that does not.  Both test systems running the same
version of vim, python, mono, vim-fsharp and with the same .vimrc on arch Linux.
The only noticeable difference between the two test systems is kernel version
and cpu (4.4.0/intel on working system, 4.2.5/amd on error system).

Fixes #33