### PR TITLE
Add options to turn off default key bindings and to reconfigure them i…

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -144,6 +144,50 @@ This enables the helptext to be displayed during auto completion. Turn off if co
 let g:fsharp_completion_helptext = 1
 ~~~
 
+If you find the default bindings unsuitable then it is possible to turn them off.
+
+~~~.vim
+let g:fsharp_map_keys = 0
+~~~
+
+It is also possible to configure them to provide a more customised experience.
+
+Override the default prefix of `<leader>` to the keys `cp`
+
+~~~.vim
+let g:fsharp_map_prefix = 'cp'
+~~~
+
+Override the default mapping to send the current like to fsharp interactive
+
+~~~.vim
+let g:fsharp_map_fsisendline = 'p'
+~~~
+
+Override the default mapping to send the current selection to fsharp interactive
+
+~~~.vim
+let g:fsharp_map_fsisendsel = 'p'
+~~~
+
+Override the default mapping to go to declaration in the current window
+
+~~~.vim
+let g:fsharp_map_gotodecl = 'g'
+~~~
+
+Override the default mapping to go back to where go to declaration was triggered
+
+~~~.vim
+let g:fsharp_map_gobackfromdecl = 'b'
+~~~
+
+Override the default mapping to evaluate an fsharp expression in the fsi
+
+~~~.vim
+let g:fsharp_map_fsiinput = 'i'
+~~~
+
 ### Troubleshooting
 
 > I get syntax highlighting but not error checking and commands like :FsiEval are not found

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -63,11 +63,36 @@ if '.fs' == ext or '.fsi' == ext:
         G.fsac.project(proj_file)
 G.fsac.parse(b.name, True, b)
 EOF
+    if !exists('g:fsharp_map_keys')
+        let g:fsharp_map_keys = 1
+    endif
 
-    nnoremap <buffer> <leader>t :call fsharpbinding#python#TypeCheck()<cr>
-    nnoremap <buffer> <leader>d :call fsharpbinding#python#GotoDecl()<cr>
-    nnoremap <buffer> <leader>s :call fsharpbinding#python#GoBackFromDecl()<cr>
-    nnoremap <buffer> <leader>e :call fsharpbinding#python#FsiInput()<cr>
+    if !exists('g:fsharp_map_prefix')
+        let g:fsharp_map_prefix = '<leader>'
+    endif
+
+    if !exists('g:fsharp_map_typecheck')
+        let g:fsharp_map_typecheck = 't'
+    endif
+
+    if !exists('g:fsharp_map_gotodecl')
+        let g:fsharp_map_gotodecl = 'd'
+    endif
+
+    if !exists('g:fsharp_map_gobackfromdecl')
+        let g:fsharp_map_gobackfromdecl = 's'
+    endif
+
+    if !exists('g:fsharp_map_fsiinput')
+        let g:fsharp_map_fsiinput = 'e'
+    endif
+
+    if g:fsharp_map_keys
+        execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_typecheck  ":call fsharpbinding#python#TypeCheck()<CR>"
+        execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_gotodecl  ":call fsharpbinding#python#GotoDecl()<CR>"
+        execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_gobackfromdecl  ":call fsharpbinding#python#GoBackFromDecl()<CR>"
+        execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_fsiinput  ":call fsharpbinding#python#FsiInput()<CR>"
+    endif
 
     com! -buffer FSharpLogFile call fsharpbinding#python#LoadLogFile()
     com! -buffer FSharpToggleHelptext call fsharpbinding#python#ToggleHelptext()
@@ -84,10 +109,21 @@ EOF
     com! -buffer -nargs=1 FsiEval call fsharpbinding#python#FsiEval(<q-args>)
     com! -buffer FsiEvalBuffer call fsharpbinding#python#FsiSendAll()
 
-    nnoremap  :<C-u>call fsharpbinding#python#FsiSendLine()<cr>
-    vnoremap  :<C-u>call fsharpbinding#python#FsiSendSel()<cr>
-    nnoremap <leader>i :<C-u>call fsharpbinding#python#FsiSendLine()<cr>
-    vnoremap <leader>i :<C-u>call fsharpbinding#python#FsiSendSel()<cr>
+    if !exists('g:fsharp_map_fsisendline')
+        let g:fsharp_map_fsisendline = 'i'
+    endif
+
+    if !exists('g:fsharp_map_fsisendsel')
+        let g:fsharp_map_fsisendsel = 'i'
+    endif
+
+    if g:fsharp_map_keys
+        nnoremap  :<C-u>call fsharpbinding#python#FsiSendLine()<cr>
+        vnoremap  :<C-u>call fsharpbinding#python#FsiSendSel()<cr>
+
+        execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_fsisendline  ":call fsharpbinding#python#FsiSendLine()<CR>"
+        execute "vnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_fsisendsel  ":call fsharpbinding#python#FsiSendSel()<CR>"
+    endif
 
     augroup fsharpbindings_au
         au!


### PR DESCRIPTION
Hi, 

Thanks for putting together this plugin. 👍 

I have not been using the plugin very long but have been using vim for quite some time. One of the first things I noticed was that installing the plugin caused some of my keybindings to be overwritten. For instance, I tend to use `<leader>s` to open a new vertical split but with this plugin installed that would attempt to take me back to the location where I triggered a go to declaration. 

I've added an option to stop the plugin from creating bindings and I've also added an option to set custom bindings. As an example, setting the following in my `.vimrc` allows me to override the default `<leader>` prefix and each of the individual bindings. 

```
let g:fsharp_map_prefix = 'cp'
let g:fsharp_map_fsisendline = 'p'
let g:fsharp_map_fsisendsel = 'p'
let g:fsharp_map_gotodecl = 'g'
let g:fsharp_map_gobackfromdecl = 'b'
let g:fsharp_map_fsiinput = 'i'
```

I hope this is helpful, if there is anything I can do to make it better then let me know. Forgive my bad spelling of off in the commit message. 😊 

Thanks again, 
Mark