### PR TITLE
fsharpXml should contain itself to allow nested markup

### DIFF
--- a/syntax/fsharp.vim
+++ b/syntax/fsharp.vim
@@ -33,7 +33,7 @@ syn keyword  fsharpScript contained line error warning light nowarn
 " comments
 syn match    fsharpComment "//.*$" contains=fsharpTodo,@Spell
 syn region   fsharpDocComment start="///" end="$" contains=fsharpTodo,fsharpXml,@Spell keepend oneline
-syn region   fsharpXml matchgroup=fsharpXmlDoc start="<[^>]\+>" end="</[^>]\+>" contained
+syn region   fsharpXml matchgroup=fsharpXmlDoc start="<[^>]\+>" end="</[^>]\+>" contained contains=fsharpXml
 
 " Double-backtick identifiers
 syn region   fsharpDoubleBacktick start="``" end="``"  keepend oneline


### PR DESCRIPTION
I had a similar `remarks` section to the one below in my code, and noticed that the nested code region was not properly highlighted:

<img width="373" alt="screen shot 2017-02-20 at 23 05 28" src="https://cloud.githubusercontent.com/assets/1846147/23156898/160186cc-f819-11e6-874c-80da66e1a7cd.png">

This PR fixes the issue by allowing the `fsharpXml` syntax element to contain itself.

<img width="370" alt="screen shot 2017-02-20 at 23 04 31" src="https://cloud.githubusercontent.com/assets/1846147/23156916/2fb35e42-f819-11e6-912f-6cb7c8828dd3.png">
