### PR TITLE
Temporary fix for unwanted stdout messages from Mono V5.0.1.1

### DIFF
--- a/ftplugin/fsharpvim.py
+++ b/ftplugin/fsharpvim.py
@@ -116,6 +116,11 @@ class FSAutoComplete:
                 self.logfile2.write("::work read: %s" % data)
                 self.logfile2.flush()
 
+            # Temporary fix for unwanted stdout messages from Mono V5.0.1.1
+            # To be removed for the next Mono release
+            if data[0] != '{':
+                continue
+
             parsed = json.loads(data)
             if parsed['Kind'] == "completion":
                 self.completion.update(parsed['Data'])


### PR DESCRIPTION
This is a quickfix for the Malformed JSON "non-IL or abstract method with non-zero RVA" error. The idea is to ignore any stdout messages which do not start with a '{'.

It is to be removed at next Mono release.