### PR TITLE
Expand doc and exception message regarding g:fsharp_interactive_bin

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -126,6 +126,12 @@ let g:fsharpbinding_debug = 1
 This will create two log files `log.txt` and `log2.txt` in your temporary folder
 (i.e. `/tmp/`).
 
+Override the default F# interactive binary
+
+~~~.vim
+let g:fsharp_interactive_bin = '/path/to/fsi'
+~~~
+
 You can set the msbuild/xbuild path.
 
 ~~~.vim

--- a/ftplugin/fsi.py
+++ b/ftplugin/fsi.py
@@ -21,7 +21,11 @@ class FSharpInteractive:
         command = [fsi_path, '--fsi-server:%s' % id, '--nologo']
         opts = { 'stdin': PIPE, 'stdout': PIPE, 'stderr': PIPE, 'shell': False, 'universal_newlines': True }
         hidewin.addopt(opts)
-        self.p = Popen(command, **opts)
+
+        try:
+            self.p = Popen(command, **opts)
+        except Exception as e:
+            raise Exception ('Error executing fsi.  g:fsharp_interactive_bin="' + fsi_path + '" ' + str(e))
 
         if is_debug:
             logfiledir = tempfile.gettempdir() + "/fsi-log.txt"


### PR DESCRIPTION
Add a reference to the ```g:fsharp_interactive_bin``` variable to the readme for settings.  Also add a more detailed exception message when the fsi call fails.

Background: When I initially setup vim-fsharp on my machine, the default bin didn't work for me.  This pull request is intended to help others in the future diagnosis and resolve similar issues.