### PR TITLE
Enable syntastic checker (by default)

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -114,6 +114,12 @@ In case you would prefer not to have you errors checked continuously add the fol
 let g:fsharp_only_check_errors_on_write = 1
 ~~~
 
+In case you prefer to disable the syntax checker, add the following to your vimrc:
+
+~~~.vim
+let g:syntastic_fsharp_checkers = ['']
+~~~
+
 ### Settings
 
 You can enable *debug-mode* in order to inspect the fsautocomplete behavior by

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -1,6 +1,6 @@
 " Vim filetype plugin
 " Language:     F#
-" Last Change:  Sat 04 Feb 2017
+" Last Change:  Sun 25 Jun 2017
 " Maintainer:   Gregor Uhlenheuer <kongo2002@googlemail.com>
 
 if exists('b:did_ftplugin')
@@ -20,6 +20,10 @@ if !exists('g:fsharp_only_check_errors_on_write')
 endif
 if !exists('g:fsharp_completion_helptext')
     let g:fsharp_completion_helptext = 1
+endif
+" Enable checker by default
+if !exists('g:syntastic_fsharp_checkers')
+    let g:syntastic_fsharp_checkers = ['syntax']
 endif
 
 let s:cpo_save = &cpo


### PR DESCRIPTION
I presume the goal is to have the syntastic syntax checker enabled by default.  On my machine that wasn't the case.  This PR resolves the g:syntastic_fsharp_checkers variable not being set.