### PR TITLE
automatically show fsi-out buffer when executing fsieval

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -200,6 +200,13 @@ Override the default mapping to evaluate an fsharp expression in the fsi
 let g:fsharp_map_fsiinput = 'i'
 ~~~
 
+Automatically open the result of an FsiEval (fsi-out buffer) in a vsplit window
+
+~~~.vim
+let g:fsharp_fsi_show_auto_open = 1
+~~~
+
+
 ### Troubleshooting
 
 > I get syntax highlighting but not error checking and commands like :FsiEval are not found

--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -427,6 +427,13 @@ function! fsharpbinding#python#FsiEval(text)
         call fsharpbinding#python#FsiSend(a:text)
         if bufnr('fsi-out') == -1
             exec 'badd fsi-out'
+
+            " auto-open the fsi-out buffer
+            if exists('g:fsharp_fsi_show_auto_open')
+                if g:fsharp_fsi_show_auto_open == 1
+                    call fsharpbinding#python#FsiShow()
+                endif
+            endif
         endif
         call fsharpbinding#python#FsiRead(5)
     catch


### PR DESCRIPTION
This PR adds an optional feature to automatically show the fsi-out buffer when an FsiEval is run (if it's not already displayed). It's a small thing, but it saves the user from having to explicitly open the buffer to see execution results.  I also setup a global config value.  No default functionality was changed; this is an optional feature.
