### PR TITLE
Add support for displaying triple-slash comments

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -89,6 +89,7 @@ Omnicomplete triggers the fsharp autocomplete process. (suggestion: install [sup
 * `:FSharpRunTests` If `g:fsharp_test_runner` is set it will build the current project and run any tests. (Currently only tested with nunit-console.exe)
 * `:FSharpToggleHelptext` toggles g:fsharp_completion_helptext. (See below for details)
 * `leader<t>` Echoes the type of the expression currently pointed to by the cursor.
+* `leader<h>` Echoes the help info (type and comments) of the expression currently pointed to by the cursor.
 * `leader<d>` _go to declaration_ in current window.
 * `leader<s>` Takes you back from where _go to declaration_ was triggered. Experimental.
 

--- a/README.mkd
+++ b/README.mkd
@@ -157,6 +157,12 @@ This enables the helptext to be displayed during auto completion. Turn off if co
 let g:fsharp_completion_helptext = 1
 ~~~
 
+Show comments, in addition to type signature, when using Omni completion (default=0).
+
+~~~.vim
+let g:fsharp_helptext_comments = 1
+~~~
+
 If you find the default bindings unsuitable then it is possible to turn them off.
 
 ~~~.vim

--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -240,7 +240,8 @@ for line in G.fsac.complete(b.name, row, col + 1, vim.eval('a:base')):
         name = "``%s``" % name
     glyph = str(line['Glyph'])
     if int(vim.eval('g:fsharp_completion_helptext')) > 0:
-        ht = G.fsac.helptext(name)
+        include_comments = vim.eval('g:fsharp_helptext_comments') != '0'
+        ht = G.fsac.helptext(name, include_comments)
         x = {'word': name,
              'abbr': abbr,
              'info': ht,

--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -130,22 +130,36 @@ function! fsharpbinding#python#RunTests(...)
     endtry
 endfunction
 
-function! fsharpbinding#python#TypeCheck()
+" Get type information for the expression at the cursor
+" includeComments [0|1]
+function! fsharpbinding#python#TypeInfo(includeComments)
     exe s:py_env
 b = vim.current.buffer
 G.fsac.parse(b.name, True, b)
 row, col = vim.current.window.cursor
-res = G.fsac.tooltip(b.name, row, col + 1)
+res = G.fsac.tooltip(b.name, row, col + 1, vim.eval('a:includeComments') != '0')
 lines = res.splitlines()
 first = ""
 if len(lines):
     first = lines[0]
 if first.startswith('Multiple') or first.startswith('type'):
     vim.command('echo "%s"' % res)
+elif first.startswith('HasComments'):
+    vim.command('echo "%s"' % res.replace("HasComments", "", 1))
 else:
     vim.command('echo "%s"' % first)
 EOF
     let b:fsharp_buffer_changed = 0
+endfunction
+
+" Get a type definition for an expression
+function! fsharpbinding#python#TypeCheck()
+    call fsharpbinding#python#TypeInfo(0)
+endfunction
+
+" Get a type definition and available comment block for an expression
+function! fsharpbinding#python#TypeHelp()
+    call fsharpbinding#python#TypeInfo(1)
 endfunction
 
 " probable loclist format

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -21,6 +21,9 @@ endif
 if !exists('g:fsharp_completion_helptext')
     let g:fsharp_completion_helptext = 1
 endif
+if !exists('g:fsharp_helptext_comments')
+    let g:fsharp_helptext_comments= 0
+endif
 " Enable checker by default
 if !exists('g:syntastic_fsharp_checkers')
     let g:syntastic_fsharp_checkers = ['syntax']

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -88,6 +88,10 @@ EOF
         let g:fsharp_map_typecheck = 't'
     endif
 
+    if !exists('g:fsharp_map_typehelp')
+        let g:fsharp_map_typehelp = 'h'
+    endif
+
     if !exists('g:fsharp_map_gotodecl')
         let g:fsharp_map_gotodecl = 'd'
     endif
@@ -102,6 +106,7 @@ EOF
 
     if g:fsharp_map_keys
         execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_typecheck  ":call fsharpbinding#python#TypeCheck()<CR>"
+        execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_typehelp  ":call fsharpbinding#python#TypeHelp()<CR>"
         execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_gotodecl  ":call fsharpbinding#python#GotoDecl()<CR>"
         execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_gobackfromdecl  ":call fsharpbinding#python#GoBackFromDecl()<CR>"
         execute "nnoremap <buffer>" g:fsharp_map_prefix.g:fsharp_map_fsiinput  ":call fsharpbinding#python#FsiInput()<CR>"

--- a/ftplugin/fsharpvim.py
+++ b/ftplugin/fsharpvim.py
@@ -246,24 +246,33 @@ class FSAutoComplete:
 
         return output
 
-    def helptext(self, candidate):
+    def helptext(self, candidate, include_comments):
+        """Get the helptext for an expression (used for omni completion)"""
         msg = self._helptext.send('helptext %s\n' % candidate)
         if msg == None:
             return ""
 
-        output = ""
+        output_signature = ""
         for ols in msg['Overloads']:
             for ol in ols:
-                output = output + self._vim_encode(ol['Signature']) + "\n"
+                output_signature = output_signature + self._vim_encode(ol['Signature']) + "\n"
 
-        msg = output
+        output_comments = ""
+        if include_comments:
+            for ols in msg['Overloads']:
+                for ol in ols:
+                    output_comments = output_comments + self._format_comment(ol['Comment']) + "\n"
+        
+        if include_comments and output_comments.strip() != "":
+            msg = '%s\n%s' % (output_signature, output_comments)
+        else:
+            msg = output_signature
 
-        if "\'" in msg and "\"" in msg:
-            msg = msg.replace("\"", "") #HACK: dictionary parsing in vim gets weird if both ' and " get printed in the same string
+        if "\'" in msg and "\\\"" in msg:
+            msg = msg.replace("\\\"", "\'") #HACK: dictionary parsing in vim gets weird if both ' and " get printed in the same string, so replace " with '
         elif "\n" in msg:
             msg = msg + "\n\n'" #HACK: - the ' is inserted to ensure that newlines are interpreted properly in the preview window
         return msg
-
 
 class FSharpVimFixture(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR adds the ability to show triple-slash comments. If you like the functionality, but don't like where I have it wired in, let me know.  I'm flexible, but these seemed like the most logical places.

Method 1: <leader>h (help).  It's like <leader>t, but additionally displays expression comments/documentation if available.

Method 2: configuration variable ```g:fsharp_helptext_comments``` enables comments to be included in omni completion display.

Examples:
![sample_tripleslash_leader_h](https://user-images.githubusercontent.com/12050360/28000930-f0e7f812-64f6-11e7-8cae-4a7a8b280ec5.png)

![sample_tripleslash_onmicompletion](https://user-images.githubusercontent.com/12050360/28000936-f53dd120-64f6-11e7-9dc9-f99c4803fdce.png)

