### PR TITLE
Ensure python/mono stop on exit

### DIFF
--- a/autoload/fsharpbinding/python.vim
+++ b/autoload/fsharpbinding/python.vim
@@ -334,6 +334,14 @@ function! fsharpbinding#python#OnTextChangedI()
     let b:fsharp_buffer_changed = 1
 endfunction
 
+" Ensure that python processes close on exit
+function! fsharpbinding#python#OnVimLeave()
+exe s:py_env
+G.fsac.shutdown()
+G.fsi.shutdown()
+EOF
+endfunction
+
 function! fsharpbinding#python#OnBufEnter()
     let b:fsharp_buffer_changed = 1
     set updatetime=500

--- a/ftplugin/fsharp.vim
+++ b/ftplugin/fsharp.vim
@@ -162,6 +162,9 @@ EOF
         au InsertLeave  *.fs,*.fsi,*fsx  if pumvisible() == 0|silent! pclose|endif
     augroup END
 
+    " Python process cleanup
+    autocmd VimLeavePre * call fsharpbinding#python#OnVimLeave()
+
     " omnicomplete
     setlocal omnifunc=fsharpbinding#python#Complete
 endif

--- a/ftplugin/fsharpvim.py
+++ b/ftplugin/fsharpvim.py
@@ -118,7 +118,7 @@ class FSAutoComplete:
 
             # Temporary fix for unwanted stdout messages from Mono V5.0.1.1
             # To be removed for the next Mono release
-            if data[0] != '{':
+            if (len(data) == 0 or data[0] != '{'):
                 continue
 
             parsed = json.loads(data)
@@ -273,6 +273,14 @@ class FSAutoComplete:
         elif "\n" in msg:
             msg = msg + "\n\n'" #HACK: - the ' is inserted to ensure that newlines are interpreted properly in the preview window
         return msg
+
+    def shutdown(self):
+        """Shutdown fsautocomplete process"""
+        try:
+            self.send("quit\n")
+            self.p.kill()
+        except:
+            pass
 
 class FSharpVimFixture(unittest.TestCase):
     def setUp(self):

--- a/ftplugin/fsi.py
+++ b/ftplugin/fsi.py
@@ -48,9 +48,13 @@ class FSharpInteractive:
             self.logfile.flush()
 
     def shutdown(self):
+        """Shutdown fsi process"""
         print("shutting down fsi")
         self._should_work = False
-        self.p.kill()
+        try:
+            self.p.kill()
+        except:
+            pass
 
     def set_loc(self, path, line_num):
         self.p.stdin.write("#" + str(line_num) + " @\"" + path + "\"\n")


### PR DESCRIPTION
When exiting, force-kill the python/mono process for fsautocomplete and fsi.  

Reason: I have run into semi-rare cases where the mono process hangs around after vim closes. In these cases mono manically consumes cpu and memory until it crashes. The force kill fixes this for me.
