### PR TITLE
install.fsx: use Tls12 when downloading

### DIFF
--- a/install.fsx
+++ b/install.fsx
@@ -26,6 +26,7 @@ let acVersion = "0.34.0"
 Target "FSharp.AutoComplete" (fun _ ->
   CreateDir vimBinDir
   use client = new WebClient()
+  Net.ServicePointManager.SecurityProtocol <- Net.SecurityProtocolType.Tls12
   tracefn "Downloading version %s of FSharp.AutoComplete" acVersion
   client.DownloadFile(sprintf "https://github.com/fsharp/FSharp.AutoComplete/releases/download/%s/%s" acVersion acArchive, vimBinDir @@ acArchive)
   tracefn "Download complete"


### PR DESCRIPTION
A while ago github switched to Tls12 only, that the default security protocol for .net will not work anymore.
Setting it manually fixes the problem.