### PR TITLE
fix rendering on vim

### DIFF
--- a/ftdetect/fsharp.vim
+++ b/ftdetect/fsharp.vim
@@ -1,2 +1,9 @@
 " F#, fsharp
+
+" regexpengine=1 is for fast rendering of fsharp.vim syntax.
+" regexpengine must be set before filetype setting.
+if !has('nvim') && !has('gui_running')
+    autocmd  BufNewFile,BufRead *.fs,*.fsi,*.fsx  set regexpengine=1
+endif
+
 autocmd BufNewFile,BufRead *.fs,*.fsi,*.fsx set filetype=fsharp

--- a/ftdetect/fsharp.vim
+++ b/ftdetect/fsharp.vim
@@ -1,9 +1,2 @@
 " F#, fsharp
-
-" regexpengine=1 is for fast rendering of fsharp.vim syntax.
-" regexpengine must be set before filetype setting.
-if !has('nvim') && !has('gui_running')
-    autocmd  BufNewFile,BufRead *.fs,*.fsi,*.fsx  set regexpengine=1
-endif
-
 autocmd BufNewFile,BufRead *.fs,*.fsi,*.fsx set filetype=fsharp

--- a/syntax/fsharp.vim
+++ b/syntax/fsharp.vim
@@ -45,7 +45,7 @@ syn match fsharpSymbol "\%(member\)\@<=\s\+\w\+\.\zs\w\+"
 
 
 " types
-syn match    fsharpTypeName   "\%(\<type\s\+\)\@<=\w\+"
+syn match    fsharpTypeName   "\%#=1\%(\<type\s\+\)\@<=\w\+"
 
 
 " errors
@@ -180,7 +180,7 @@ syn match    fsharpFloat         "\<-\=\d\(_\|\d\)*\.\(_\|\d\)*\([eE][-+]\=\d\(_
 syn match    fsharpFloat         "\<\d\+\.\d*"
 
 " modules
-syn match    fsharpModule     "\%(\<open\s\+\)\@<=[a-zA-Z.]\+"
+syn match    fsharpModule     "\%#=1\%(\<open\s\+\)\@<=[a-zA-Z.]\+"
 
 " attributes
 syn region   fsharpAttrib matchgroup=fsharpAttribute start="\[<" end=">]"


### PR DESCRIPTION
Hello! I'm `callmekohei`! (^_^)/

### problem

[syntax file](https://github.com/fsharp/vim-fsharp/blob/master/syntax/fsharp.vim) make it slow rendering on vim.

```vim
fsharpModule       \%(\<open\s\+\)\@<=[a-zA-Z.]\+
fsharpTypeName     \%(\<type\s\+\)\@<=\w\+
```

### Environment

```shell
$ sw_vers 
ProductName:	Mac OS X
ProductVersion:	10.13.4
BuildVersion:	17E202

$ vim --version | head -n 5
VIM - Vi IMproved 8.1 (2018 May 17, compiled May 22 2018 22:51:49)
macOS version
Included patches: 1
Compiled by Homebrew
Huge version without GUI.  Features included (+) or not (-):
```

### Test

prepare syntax file and test file
```shell
$ mkdir foo
$ cd foo/
$ wget 'https://raw.githubusercontent.com/fsharp/vim-fsharp/master/syntax/fsharp.vim' -P './rc/syntax/'
$ wget https://gist.github.com/callmekohei/a48caad1fe0849099131c10385505999#file-foo-fsx
```
create minimal.vimrc

```shell
$ vim minimal.vimrc
```

```vim
" set path, set filetyp
set runtimepath+=./rc
autocmd BufNewFile,BufRead *.fsx  set filetype=fsharp

" turn plugins on
syntax enable
filetype plugin indent on

" flag
" set regexpengin=1
```

create test report ( see vim help :h syntime )
```shell
# open foo.fsx
$ vim -N -u minimal.vimrc foo.fsx 

# start test mode
: syntime on

# redraw 10 times
<C-l>
<C-l>
<C-l>
<C-l>
<C-l>
<C-l>
<C-l>
<C-l>
<C-l>
<C-l>

# end test mode
: syntime off

# put report
: redir > foo.txt
: silent syntime report
```
create bar.txt
```shell
# comment out in minimal.vimrc
$ vim minimal.vmrc
set regexpengin=1

# do test
...
: redir > bar.txt
: silent syntime report
```

### result
foo.txt
```text
regexpengine=0
 TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN
 1.659369   330    30      0.011410    0.005028  fsharpModule       \%(\<open\s\+\)\@<=[a-zA-Z.]\+
 1.578941   330    0       0.009866    0.004785  fsharpTypeName     \%(\<type\s\+\)\@<=\w\+
 0.021088   330    0       0.000144    0.000064  fsharpSymbol       \%(let\|use\|mutable\|rec\|and\|private\)\@<=!\=\s\+\z
 0.015800   330    0       0.000098    0.000048  fsharpSymbol       \%(member\)\@<=\s\+\w\+\.\zs\w\+
 0.013732   270    0       0.000092    0.000051  fsharpRegion       \%(end\)\@<!region.*$
 0.012374   360    60      0.000085    0.000034  fsharpNumber       \<-\=\d\(_\|\d\)*\(u\|u\?[yslLn]\|UL\)\?\>
 0.011798   330    0       0.000074    0.000036  fsharpFloat        \<-\=\d\(_\|\d\)*\.\(_\|\d\)*\([eE][-+]\=\d\(_\|\d\)*\
 0.011766   330    0       0.000084    0.000036  fsharpNumber       \<-\=0[o|O]\(\o\|_\)\+\(u\|u\?[yslLn]\|UL\)\?\>
```
bar.txt
```
regexpengine=1
 TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN
 0.265682   330    30      0.001915    0.000805  fsharpModule       \%(\<open\s\+\)\@<=[a-zA-Z.]\+
 0.225018   330    0       0.001335    0.000682  fsharpTypeName     \%(\<type\s\+\)\@<=\w\+
 0.005389   330    0       0.000067    0.000016  fsharpSymbol       \%(let\|use\|mutable\|rec\|and\|private\)\@<=!\=\s\+\z
 0.004259   330    0       0.000035    0.000013  fsharpCharacter    '\\\d\d\d'\|'\\[\'ntbr]'\|'.'
 0.003339   330    0       0.000024    0.000010  fsharpCharErr      '\\\d\d'\|'\\\d'
 0.002938   270    0       0.000022    0.000011  fsharpString       \\\\\|\\"
 0.002282   330    0       0.000041    0.000007  fsharpSymbol       \%(member\)\@<=\s\+\w\+\.\zs\w\+
 0.002089   360    60      0.000018    0.000006  fsharpNumber       \<-\=\d\(_\|\d\)*\(u\|u\?[yslLn]\|UL\)\?\>
```
### additional info
Two options ( number, nowrap ) makas more slow. 😢 
```vim
" You fell more slow if you add two options.
set number
set nowrap
```
