### PR TITLE
Add an error message for the case fsautocomplete.exe is not built

### DIFF
--- a/ftplugin/fsharpvim.py
+++ b/ftplugin/fsharpvim.py
@@ -66,7 +66,11 @@ class FSAutoComplete:
         else:
             self.logfile = None
 
-        command = ['mono', dir + '/bin/fsautocomplete.exe']
+        fsautocomplete = dir + '/bin/fsautocomplete.exe'
+        if not path.exists(fsautocomplete):
+            msg = 'fsautocomplete.exe is not found: Did you build it with "make fsautocomplete"?'
+            raise FileNotFoundError(msg)
+        command = ['mono', fsautocomplete]
         opts = { 'stdin': PIPE, 'stdout': PIPE, 'stderr': PIPE, 'universal_newlines': True }
         hidewin.addopt(opts)
         try:


### PR DESCRIPTION
I got the same error to #106 and it was caused by forgetting building `fsautocomplete.exe`. Adding `build = "make fsautocomplete"` to my `dein.toml` solved this problem.
The current error message `BrokenPipeError: [Errno 32] Broken pipe` is unhelpful, so this pull request replace it.